### PR TITLE
perf: JOIN FETCH N+1 제거 + 범위 쿼리 + 크롤러 백오프 (fixes #12)

### DIFF
--- a/backend/src/main/java/com/teacherhub/controller/ReportController.java
+++ b/backend/src/main/java/com/teacherhub/controller/ReportController.java
@@ -45,7 +45,7 @@ public class ReportController {
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
 
         LocalDate reportDate = date != null ? date : LocalDate.now();
-        List<DailyReport> reports = dailyReportRepository.findByReportDate(reportDate);
+        List<DailyReport> reports = dailyReportRepository.findByReportDateWithTeacher(reportDate);
 
         PeriodReportDTO result = buildPeriodReport(
                 "daily",
@@ -74,13 +74,8 @@ public class ReportController {
         LocalDate weekStart = getWeekStartDate(targetYear, targetWeek);
         LocalDate weekEnd = weekStart.plusDays(6);
 
-        // 해당 기간의 일별 리포트 조회
-        List<DailyReport> allReports = new ArrayList<>();
-        LocalDate current = weekStart;
-        while (!current.isAfter(weekEnd)) {
-            allReports.addAll(dailyReportRepository.findByReportDate(current));
-            current = current.plusDays(1);
-        }
+        // 해당 기간의 일별 리포트 조회 (단일 범위 쿼리 + JOIN FETCH)
+        List<DailyReport> allReports = dailyReportRepository.findByReportDateBetweenWithTeacher(weekStart, weekEnd);
 
         PeriodReportDTO result = buildPeriodReport(
                 "weekly",
@@ -111,13 +106,8 @@ public class ReportController {
         LocalDate monthStart = LocalDate.of(targetYear, targetMonth, 1);
         LocalDate monthEnd = monthStart.plusMonths(1).minusDays(1);
 
-        // 해당 월의 일별 리포트 조회
-        List<DailyReport> allReports = new ArrayList<>();
-        LocalDate current = monthStart;
-        while (!current.isAfter(monthEnd)) {
-            allReports.addAll(dailyReportRepository.findByReportDate(current));
-            current = current.plusDays(1);
-        }
+        // 해당 월의 일별 리포트 조회 (단일 범위 쿼리 + JOIN FETCH)
+        List<DailyReport> allReports = dailyReportRepository.findByReportDateBetweenWithTeacher(monthStart, monthEnd);
 
         PeriodReportDTO result = buildPeriodReport(
                 "monthly",

--- a/backend/src/main/java/com/teacherhub/service/AnalysisService.java
+++ b/backend/src/main/java/com/teacherhub/service/AnalysisService.java
@@ -65,7 +65,7 @@ public class AnalysisService {
     }
 
     public Map<String, Object> getSummary(LocalDate date) {
-        List<DailyReport> reports = dailyReportRepository.findByReportDate(date);
+        List<DailyReport> reports = dailyReportRepository.findByReportDateWithTeacher(date);
         Map<String, Object> summary = aggregateSentimentStats(reports);
         summary.put("date", date);
         summary.put("totalTeachers", reports.size());
@@ -73,7 +73,7 @@ public class AnalysisService {
     }
 
     public List<Map<String, Object>> getAcademyStats(LocalDate date) {
-        List<DailyReport> reports = dailyReportRepository.findByReportDate(date);
+        List<DailyReport> reports = dailyReportRepository.findByReportDateWithTeacher(date);
 
         Map<String, List<DailyReport>> byAcademy = reports.stream()
                 .filter(r -> r.getTeacher() != null && r.getTeacher().getAcademy() != null)


### PR DESCRIPTION
## Summary
- DailyReport → Teacher → Academy/Subject 체인의 N+1 쿼리를 `JOIN FETCH`로 제거
- 주별/월별 리포트: 7~30일 루프 쿼리 → `BETWEEN` 단일 범위 쿼리로 통합
- 크롤러 `safe_goto`에 지수 백오프 재시도 추가 (최대 3회, 1s/2s/4s)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `DailyReportRepository` | `findByReportDateWithTeacher`, `findByReportDateBetweenWithTeacher` JOIN FETCH 쿼리 추가 |
| `ReportController` | daily/weekly/monthly 모든 엔드포인트 JOIN FETCH 전환 |
| `AnalysisService` | `getSummary`, `getAcademyStats` JOIN FETCH 전환 |
| `BaseCrawler` | `safe_goto` 지수 백오프 재시도 (max_retries=3) |

## Performance Impact
- 일별 리포트: 1 + 3N 쿼리 → 1 쿼리 (N=강사 수, 100% JOIN FETCH)
- 주별 리포트: 7 + 21N 쿼리 → 1 쿼리 (루프+N+1 동시 제거)
- 월별 리포트: 30 + 90N 쿼리 → 1 쿼리 (루프+N+1 동시 제거)
- 크롤러: 일시 장애 시 즉시 실패 → 재시도 후 복구

## Test plan
- [ ] `GET /api/v2/reports/daily` Teacher/Academy/Subject 정보 포함 확인
- [ ] `GET /api/v2/reports/weekly` 주간 집계 데이터 정상 확인
- [ ] `GET /api/v2/reports/monthly` 월간 집계 데이터 정상 확인
- [ ] `GET /api/v2/analysis/summary` 요약 데이터 정상 확인
- [ ] `GET /api/v2/analysis/academy-stats` 학원별 통계 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)