### PR TITLE
perf: N+1 쿼리 해결 + 크롤러 배치 + DB 풀 설정 (#25~#30)

### DIFF
--- a/ai-crawler/src/database.py
+++ b/ai-crawler/src/database.py
@@ -18,8 +18,14 @@ DB_NAME = os.getenv("DB_NAME", "teacherhub")
 
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
-# Engine & Session
-engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+# Engine & Session (커넥션 풀 설정)
+engine = create_engine(
+    DATABASE_URL,
+    pool_size=5,
+    max_overflow=10,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 ScopedSession = scoped_session(SessionLocal)
 

--- a/ai-crawler/src/repositories.py
+++ b/ai-crawler/src/repositories.py
@@ -113,8 +113,7 @@ class PostRepository:
     def create(db: Session, post_data: Dict[str, Any]) -> Post:
         post = Post(**post_data)
         db.add(post)
-        db.commit()
-        db.refresh(post)
+        db.flush()
         return post
 
     @staticmethod
@@ -127,8 +126,7 @@ class PostRepository:
             return existing, False
         post = Post(source_id=source_id, external_id=external_id, **post_data)
         db.add(post)
-        db.commit()
-        db.refresh(post)
+        db.flush()
         return post, True
 
     @staticmethod
@@ -149,8 +147,7 @@ class CommentRepository:
     def create(db: Session, comment_data: Dict[str, Any]) -> Comment:
         comment = Comment(**comment_data)
         db.add(comment)
-        db.commit()
-        db.refresh(comment)
+        db.flush()
         return comment
 
     @staticmethod
@@ -165,8 +162,7 @@ class TeacherMentionRepository:
     def create(db: Session, mention_data: Dict[str, Any]) -> TeacherMention:
         mention = TeacherMention(**mention_data)
         db.add(mention)
-        db.commit()
-        db.refresh(mention)
+        db.flush()
         return mention
 
     @staticmethod
@@ -227,14 +223,12 @@ class DailyReportRepository:
         if existing:
             for key, value in report_data.items():
                 setattr(existing, key, value)
-            db.commit()
-            db.refresh(existing)
+            db.flush()
             return existing
 
         report = DailyReport(report_date=report_date, teacher_id=teacher_id, **report_data)
         db.add(report)
-        db.commit()
-        db.refresh(report)
+        db.flush()
         return report
 
     @staticmethod
@@ -273,14 +267,12 @@ class AcademyDailyStatsRepository:
         if existing:
             for key, value in stats_data.items():
                 setattr(existing, key, value)
-            db.commit()
-            db.refresh(existing)
+            db.flush()
             return existing
 
         stats = AcademyDailyStats(report_date=report_date, academy_id=academy_id, **stats_data)
         db.add(stats)
-        db.commit()
-        db.refresh(stats)
+        db.flush()
         return stats
 
 
@@ -295,8 +287,7 @@ class CrawlLogRepository:
             status='running'
         )
         db.add(log)
-        db.commit()
-        db.refresh(log)
+        db.flush()
         return log
 
     @staticmethod
@@ -310,8 +301,7 @@ class CrawlLogRepository:
             log.comments_collected = comments
             log.mentions_found = mentions
             log.error_message = error
-            db.commit()
-            db.refresh(log)
+            db.flush()
         return log
 
     @staticmethod

--- a/ai-crawler/src/services/mention_extractor.py
+++ b/ai-crawler/src/services/mention_extractor.py
@@ -128,8 +128,7 @@ class MentionExtractor:
         )
 
         self.db.add(mention)
-        self.db.commit()
-        self.db.refresh(mention)
+        self.db.flush()
 
         return mention
 
@@ -182,6 +181,13 @@ class MentionExtractor:
                 self.db.rollback()
                 continue
 
+        # 전체 처리 완료 후 1회 commit (건별 commit 대신 배치 commit)
+        try:
+            self.db.commit()
+        except Exception as e:
+            print(f"[!] Error committing batch: {e}")
+            self.db.rollback()
+
         return stats
 
     def _save_post(self, source: CollectionSource, data: Dict[str, Any]) -> tuple:
@@ -202,7 +208,7 @@ class MentionExtractor:
             existing.view_count = data.get('view_count', existing.view_count)
             existing.like_count = data.get('like_count', existing.like_count)
             existing.comment_count = data.get('comment_count', existing.comment_count)
-            self.db.commit()
+            self.db.flush()
             return existing, False
 
         # 새로 생성
@@ -220,8 +226,7 @@ class MentionExtractor:
         )
 
         self.db.add(post)
-        self.db.commit()
-        self.db.refresh(post)
+        self.db.flush()
 
         return post, True
 
@@ -250,8 +255,7 @@ class MentionExtractor:
         )
 
         self.db.add(comment)
-        self.db.commit()
-        self.db.refresh(comment)
+        self.db.flush()
 
         return comment, True
 

--- a/ai-crawler/src/services/report_generator.py
+++ b/ai-crawler/src/services/report_generator.py
@@ -106,8 +106,7 @@ class ReportGenerator:
         report.summary = summary
         report.top_keywords = top_keywords
 
-        self.db.commit()
-        self.db.refresh(report)
+        self.db.flush()
 
         return report
 
@@ -177,8 +176,7 @@ class ReportGenerator:
         stats.avg_sentiment_score = avg_sentiment
         stats.top_teacher_id = top_teacher_id
 
-        self.db.commit()
-        self.db.refresh(stats)
+        self.db.flush()
 
         return stats
 
@@ -219,6 +217,13 @@ class ReportGenerator:
             if academy_stats:
                 stats['academy_stats'] += 1
                 print(f"    - {academy.name}: {academy_stats.total_mentions} total mentions")
+
+        # 전체 리포트 생성 완료 후 1회 commit (건별 commit 대신 배치 commit)
+        try:
+            self.db.commit()
+        except Exception as e:
+            print(f"[!] Error committing reports: {e}")
+            self.db.rollback()
 
         print(f"\n[*] Report generation complete")
         print(f"    Teacher reports: {stats['teacher_reports']}")

--- a/backend/src/main/java/com/teacherhub/controller/WeeklyReportController.java
+++ b/backend/src/main/java/com/teacherhub/controller/WeeklyReportController.java
@@ -21,7 +21,6 @@ import java.util.Map;
 @RequestMapping("/api/v2/weekly")
 @RequiredArgsConstructor
 @Validated
-@CrossOrigin(origins = {"${app.cors.allowed-origins:http://localhost:3000}"})
 public class WeeklyReportController {
 
     private final WeeklyReportService weeklyReportService;

--- a/backend/src/main/java/com/teacherhub/repository/ReputationRepository.java
+++ b/backend/src/main/java/com/teacherhub/repository/ReputationRepository.java
@@ -1,9 +1,9 @@
 package com.teacherhub.repository;
 
 import com.teacherhub.domain.ReputationData;
-import com.teacherhub.dto.MonthlyStats;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -16,12 +16,16 @@ public interface ReputationRepository extends JpaRepository<ReputationData, Long
     long countByKeyword(String keyword);
 
     @Query("SELECT SUM(r.commentCount) FROM ReputationData r WHERE r.keyword = :keyword")
-    Long countTotalCommentsByKeyword(String keyword);
+    Long countTotalCommentsByKeyword(@Param("keyword") String keyword);
 
-    @Query("SELECT new com.teacherhub.dto.MonthlyStats(TO_CHAR(r.postDate, 'YYYY-MM'), COUNT(r)) " +
-            "FROM ReputationData r " +
+    /**
+     * 키워드 및 시작일 이후의 ReputationData 조회
+     * Java 코드에서 월별 그룹핑 수행 (PostgreSQL TO_CHAR 종속성 제거)
+     */
+    @Query("SELECT r FROM ReputationData r " +
             "WHERE r.keyword = :keyword AND r.postDate >= :startDate " +
-            "GROUP BY TO_CHAR(r.postDate, 'YYYY-MM') " +
-            "ORDER BY TO_CHAR(r.postDate, 'YYYY-MM')")
-    List<MonthlyStats> findMonthlyStats(String keyword, LocalDateTime startDate);
+            "ORDER BY r.postDate ASC")
+    List<ReputationData> findByKeywordAndPostDateAfter(
+            @Param("keyword") String keyword,
+            @Param("startDate") LocalDateTime startDate);
 }

--- a/backend/src/main/java/com/teacherhub/repository/WeeklyReportRepository.java
+++ b/backend/src/main/java/com/teacherhub/repository/WeeklyReportRepository.java
@@ -16,37 +16,60 @@ import java.util.Optional;
 public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long> {
 
     /**
-     * 특정 강사의 주간 리포트 조회
-     */
-    Optional<WeeklyReport> findByTeacherIdAndYearAndWeekNumber(
-        Long teacherId, Integer year, Integer weekNumber);
-
-    /**
-     * 특정 주차의 모든 리포트 조회 (순위순)
-     */
-    List<WeeklyReport> findByYearAndWeekNumberOrderByMentionCountDesc(
-        Integer year, Integer weekNumber);
-
-    /**
-     * 특정 학원의 주간 리포트 조회
-     */
-    List<WeeklyReport> findByAcademyIdAndYearAndWeekNumberOrderByMentionCountDesc(
-        Long academyId, Integer year, Integer weekNumber);
-
-    /**
-     * 강사의 최근 N주 리포트 조회
+     * 특정 강사의 주간 리포트 조회 (JOIN FETCH로 Teacher, Academy 일괄 로딩)
      */
     @Query("SELECT wr FROM WeeklyReport wr " +
-           "WHERE wr.teacher.id = :teacherId " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE t.id = :teacherId AND wr.year = :year AND wr.weekNumber = :weekNumber")
+    Optional<WeeklyReport> findByTeacherIdAndYearAndWeekNumber(
+        @Param("teacherId") Long teacherId,
+        @Param("year") Integer year,
+        @Param("weekNumber") Integer weekNumber);
+
+    /**
+     * 특정 주차의 모든 리포트 조회 (JOIN FETCH + 순위순)
+     */
+    @Query("SELECT wr FROM WeeklyReport wr " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE wr.year = :year AND wr.weekNumber = :weekNumber " +
+           "ORDER BY wr.mentionCount DESC")
+    List<WeeklyReport> findByYearAndWeekNumberOrderByMentionCountDesc(
+        @Param("year") Integer year,
+        @Param("weekNumber") Integer weekNumber);
+
+    /**
+     * 특정 학원의 주간 리포트 조회 (JOIN FETCH)
+     */
+    @Query("SELECT wr FROM WeeklyReport wr " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE a.id = :academyId AND wr.year = :year AND wr.weekNumber = :weekNumber " +
+           "ORDER BY wr.mentionCount DESC")
+    List<WeeklyReport> findByAcademyIdAndYearAndWeekNumberOrderByMentionCountDesc(
+        @Param("academyId") Long academyId,
+        @Param("year") Integer year,
+        @Param("weekNumber") Integer weekNumber);
+
+    /**
+     * 강사의 최근 N주 리포트 조회 (JOIN FETCH)
+     */
+    @Query("SELECT wr FROM WeeklyReport wr " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE t.id = :teacherId " +
            "ORDER BY wr.year DESC, wr.weekNumber DESC")
     List<WeeklyReport> findRecentByTeacherId(
         @Param("teacherId") Long teacherId,
         org.springframework.data.domain.Pageable pageable);
 
     /**
-     * 특정 주차 랭킹 조회 (상위 N명)
+     * 특정 주차 랭킹 조회 (JOIN FETCH + 상위 N명)
      */
     @Query("SELECT wr FROM WeeklyReport wr " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
            "WHERE wr.year = :year AND wr.weekNumber = :weekNumber " +
            "AND wr.mentionCount > 0 " +
            "ORDER BY wr.mentionCount DESC")
@@ -56,10 +79,12 @@ public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long
         org.springframework.data.domain.Pageable pageable);
 
     /**
-     * 학원별 주간 랭킹 조회
+     * 학원별 주간 랭킹 조회 (JOIN FETCH)
      */
     @Query("SELECT wr FROM WeeklyReport wr " +
-           "WHERE wr.academy.id = :academyId " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE a.id = :academyId " +
            "AND wr.year = :year AND wr.weekNumber = :weekNumber " +
            "ORDER BY wr.mentionCount DESC")
     List<WeeklyReport> findByAcademyAndWeek(
@@ -81,4 +106,23 @@ public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long
      */
     List<WeeklyReport> findByYearAndWeekNumberAndIsCompleteTrue(
         Integer year, Integer weekNumber);
+
+    /**
+     * 학원의 복수 주차 리포트 일괄 조회 (N+1 방지 범위 쿼리)
+     * getAcademyTrend에서 주차별 개별 쿼리 대신 사용
+     */
+    @Query("SELECT wr FROM WeeklyReport wr " +
+           "JOIN FETCH wr.teacher t " +
+           "JOIN FETCH wr.academy a " +
+           "WHERE a.id = :academyId " +
+           "AND ((wr.year = :startYear AND wr.weekNumber >= :startWeek) " +
+           "  OR (wr.year > :startYear AND wr.year < :endYear) " +
+           "  OR (wr.year = :endYear AND wr.weekNumber <= :endWeek)) " +
+           "ORDER BY wr.year ASC, wr.weekNumber ASC")
+    List<WeeklyReport> findByAcademyAndWeekRange(
+        @Param("academyId") Long academyId,
+        @Param("startYear") Integer startYear,
+        @Param("startWeek") Integer startWeek,
+        @Param("endYear") Integer endYear,
+        @Param("endWeek") Integer endWeek);
 }


### PR DESCRIPTION
## Summary
- **#25** WeeklyReportService N+1: 범위 쿼리 통합으로 개별 조회 제거
- **#26** WeeklyReportRepository JOIN FETCH: Teacher, Academy 연관 엔티티 일괄 로딩
- **#27** 크롤러 건별 commit: 배치 flush + 최종 1회 commit 패턴
- **#28** 중복 @CrossOrigin: 컨트롤러별 @CrossOrigin 제거, WebConfig 글로벌만 유지
- **#29** PostgreSQL 종속 JPQL: 표준 JPQL 또는 Java 그룹핑으로 전환
- **#30** 크롤러 DB 커넥션 풀: `pool_size=5`, `max_overflow=10`, `pool_pre_ping=True`, `pool_recycle=1800`

## 변경 파일 (9개)
- `WeeklyReportRepository.java`: JOIN FETCH 쿼리 6개 추가
- `WeeklyReportService.java`: N+1 쿼리 범위 통합
- `ReputationRepository.java`: 표준 JPQL 전환
- `ReputationController.java`: @CrossOrigin 제거
- `WeeklyReportController.java`: @CrossOrigin 제거
- `database.py`: 커넥션 풀 설정 추가
- `repositories.py`: 배치 flush + 최종 commit 패턴
- `mention_extractor.py`, `report_generator.py`: 크롤러 배치 처리

## Test plan
- [ ] 주간 리포트 조회 시 SQL 로그에서 N+1 없음 확인
- [ ] 크롤러 실행 시 DB 커넥션 풀 정상 동작 확인
- [ ] CORS 설정이 WebConfig 글로벌로만 적용되는지 확인
- [ ] 평판 데이터 조회 API 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)